### PR TITLE
Updating MainActivity.kt to comment out breaking import per codelab flow

### DIFF
--- a/audio_classification/codelab1/android/starter/app/src/main/java/com/example/mysoundclassification/MainActivity.kt
+++ b/audio_classification/codelab1/android/starter/app/src/main/java/com/example/mysoundclassification/MainActivity.kt
@@ -19,7 +19,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import org.tensorflow.lite.task.audio.classifier.AudioClassifier
+//import org.tensorflow.lite.task.audio.classifier.AudioClassifier
 import java.util.*
 import kotlin.concurrent.scheduleAtFixedRate
 


### PR DESCRIPTION
The TensorFlow import at the top of MainActivity causes the initial app to not build since there's a later step to uncomment the build.gradle dependency.