### PR TITLE
Fix the dataset url in model_maker_audio_colab.ipynb

### DIFF
--- a/audio_classification/colab/model_maker_audio_colab.ipynb
+++ b/audio_classification/colab/model_maker_audio_colab.ipynb
@@ -158,7 +158,7 @@
       },
       "source": [
         "birds_dataset_folder = tf.keras.utils.get_file('birds_dataset.zip',\n",
-        "                                                'https://storage.googleapis.com/laurencemoroney-blog.appspot.com/birds_dataset.zip',\n",
+        "                                                'https://storage.googleapis.com/learning-datasets/birds_dataset.zip',\n",
         "                                                cache_dir='./',\n",
         "                                                cache_subdir='dataset',\n",
         "                                                extract=True)\n",


### PR DESCRIPTION
The dataset url is broken. Updated the url with the active link to download the dataset. 

Fixes [#59245](https://github.com/tensorflow/tensorflow/issues/59245).

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR